### PR TITLE
Add deref-in hook

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -99,7 +99,7 @@ Example:
     
 ;; in test
 (deftest welcome-allowed
-  (is (= (hx/shallow-render (Welcome {:keys age}))
+  (is (= (hx/shallow-render (Welcome {:age 18}))
          [:div "You're allowed!"]))
   (is (= (hx/shallow-render (Welcome {:age 17}))
          [:div [:a {:href "http://disney.com"}] "Please go elsewhere"])))

--- a/src/hx/react/hooks.cljs
+++ b/src/hx/react/hooks.cljs
@@ -59,9 +59,9 @@
      v)))
 
 (defn <-deref-in
-  "Takes an atom and a sequence of keys in a nested associative structure the . 
-   Returns the currently derefed value on the key path in the atom, 
-   and re-renders the component if the value on the path changes."
+  "Takes an atom and a sequence of keys in a nested associative structure atom
+  references. Returns the currently derefed value on the key path,
+  and re-renders the component if the value changes."
   ;; if no deps are passed in, we assume we only want to run
   ;; subscrib/unsubscribe on mount/unmount
   ([a k] (<-deref-in a k []))

--- a/src/hx/react/hooks.cljs
+++ b/src/hx/react/hooks.cljs
@@ -73,8 +73,8 @@
       (fn []
         (add-watch a :use-in-atom
                    ;; update the react state on each change
-                   (fn [_ _ v v']
-                     (if-not (= (get-in v k) (get-in v' k)) (u v'))))
+                   (fn [_ _ _ v']
+                     (if-not (= v (get-in v' k)) (u (get-in v' k)))))
         ;; return a function to tell react hook how to unsubscribe
         #(remove-watch a :use-in-atom))
       ;; pass in deps vector as an array


### PR DESCRIPTION
A hook that returns value in the derefed atom on a path specified by the sequence of keys and rerenders the component, only if the value on key path changes. Any other change of the atom is ignored.

It is similar to cursor idea found in some other frameworks.

It is confirmed to work with funcool/potok state atom.

Also it is just proof of the idea, and I would appreciate any discussion.