### PR TITLE
Pass initial value to react/useRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.3.1] - Feb 20, 2019
+### Fixed
+- `<-ref`: Pass initial value to `react/useRef`
 
 ## [0.3.0] - Feb 10, 2019
 ### Changed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lilactown/hx "0.3.0"
+(defproject lilactown/hx "0.3.1"
   :description "An easy to use, decomplected hiccup compiler for ClojureScript & React."
   :url "https://github.com/Lokeh/hx"
   :license {:name "Eclipse Public License"

--- a/src/hx/hooks.cljs
+++ b/src/hx/hooks.cljs
@@ -32,7 +32,7 @@
   "Takes an initial value. Returns an atom that will _NOT_ re-render component
   on change."
   [initial]
-  (let [react-ref (react/useRef)
+  (let [react-ref (react/useRef initial)
         update-ref (fn [v] (gobj/set react-ref "current" v))]
   (Atomified. [react-ref update-ref] #(.-current ^js %))))
 


### PR DESCRIPTION
Hey, just tried to use `<-ref` and it didn't work as I expected, think it might just be that the initial state needs to be passed through to `react/useRef`. This commit adds it in. 
Thanks! 

ps I'm really glad someone's made a new minimal React wrapper for ClojureScript :) nice work!


