### PR TITLE
Add `:provider` hiccup element

### DIFF
--- a/examples/workshop/core.cljs
+++ b/examples/workshop/core.cljs
@@ -71,7 +71,7 @@
 (dc/defcard class-component
   (hx/$ ClassComp))
 
-(def some-context (hx/create-context))
+(def some-context (hx/create-context "default context value"))
 
 (hx/defnc ContextConsumer [_]
   [:div
@@ -79,9 +79,12 @@
     (fn [v]
       [:div v])]])
 
+(dc/defcard context-default
+  (hx/$ ContextConsumer))
+
 (hx/defnc ContextProvider [_]
   [:provider {:context some-context
-              :value "context value 42"}
+              :value "provider context value"}
    [:div
     [ContextConsumer]]])
 

--- a/examples/workshop/core.cljs
+++ b/examples/workshop/core.cljs
@@ -71,7 +71,7 @@
 (dc/defcard class-component
   (hx/$ ClassComp))
 
-(def some-context (react/createContext))
+(def some-context (hx/create-context))
 
 (hx/defnc ContextConsumer [_]
   [:div
@@ -80,8 +80,8 @@
       [:div v])]])
 
 (hx/defnc ContextProvider [_]
-  [(.-Provider some-context)
-   {:value "context value"}
+  [:provider {:context some-context
+              :value "context value 42"}
    [:div
     [ContextConsumer]]])
 

--- a/src/hx/react.cljc
+++ b/src/hx/react.cljc
@@ -77,6 +77,13 @@
             hx.react/fragment
             args)))
 
+#?(:cljs (defmethod hiccup/parse-element
+           :provider
+           [el {:keys [context value]} args]
+           (hiccup/-parse-element
+            (.-Provider context)
+            [{:value value}
+             args])))
 
 #?(:cljs (defn props->clj [props]
            (let [props (utils/shallow-js->clj props :keywordize-keys true)]

--- a/src/hx/react.cljc
+++ b/src/hx/react.cljc
@@ -125,10 +125,13 @@
 #?(:cljs (defn create-pure-component [init-fn static-properties method-names]
            (create-class react/PureComponent init-fn static-properties method-names)))
 
+#?(:cljs (def create-context
+           "Just react/createContext"
+           react/createContext))
+
 (defn factory
   "Takes a React component, and creates a function that returns
   a new React element"
   [component]
   (partial $ component))
-
 


### PR DESCRIPTION
Fix for #19 

This PR is to:

1. Add react/create-context thin wrapper arround react/createContext
1. Add custom hiccup element `:provider` to avoid js interop
1. Update the context example to demonstrate the usage