### PR TITLE
Only munge props when converting to native React elements

### DIFF
--- a/examples/workshop/react_dnd.cljs
+++ b/examples/workshop/react_dnd.cljs
@@ -17,8 +17,8 @@
                          :top (gobj/get props "top")
                          :text (gobj/get props "text")})})
 
-(hx/defnc BoxRender [{:keys [connect-drag-source top left text] :as props}]
-  (connect-drag-source
+(hx/defnc BoxRender [{:keys [connectDragSource top left text] :as props}]
+  (connectDragSource
    ;; we have to call hx/f directly here since `connect-drag-source` expects
    ;; a react element as it's argument, and returns a react element
    (hx/f [:div {:style {:top top

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -32,9 +32,9 @@
         props (if props? (first args) nil)
         children (if props? (rest args) args)]
     (make-node config el
-               (if props?
-                 (-> props
-                     (util/clj->props))
+               (case [(string? el) props?]
+                 [true true] (util/clj->props props)
+                 [false true] (util/shallow-clj->js props)
                  nil)
                (if (and (= (count children) 1) (fn? (first children)))
                  ;; fn-as-child

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -46,7 +46,7 @@
   (-parse-element [s _ _]
     s)
 
-  #?(:clj clojure.lang.PersistentVector 
+  #?(:clj clojure.lang.PersistentVector
      :cljs PersistentVector)
   (-parse-element [form config _]
     (apply parse-element config form))

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -18,33 +18,11 @@
   ([config el & args]
    (-parse-element el config args)))
 
-(defn- make-node [config el props children]
-  (let [{:keys [create-element]} config]
-    (if (seq? children)
-      (apply create-element el props children)
-      (create-element el props children))))
-
 (defn parse [config hiccup]
   (apply parse-element config hiccup))
 
 (defn make-element [config el args]
-  (let [props? (map? (first args))
-        props (if props? (first args) nil)
-        children (if props? (rest args) args)]
-    (make-node config el
-               (case [(string? el) props?]
-                 [true true] (util/clj->props props)
-                 [false true] (util/shallow-clj->js props)
-                 nil)
-               (if (and (= (count children) 1) (fn? (first children)))
-                 ;; fn-as-child
-                 ;; wrap in a function to parse hiccup from render-fn
-                 (fn [& args]
-                   (let [ret (apply (first children) args)]
-                     (if (vector? ret)
-                       (apply parse-element config ret)
-                       ret)))
-                 (map (partial parse-element config) children)))))
+  ((:create-element config) config el args))
 
 #?(:clj (defn array? [x]
           (coll? x)))
@@ -76,11 +54,10 @@
   #?(:clj clojure.lang.LazySeq
      :cljs LazySeq)
   (-parse-element [a config b]
-    (make-node
+    (make-element
      config
      (:fragment config)
-     nil
-     (map (partial parse-element config) a)))
+     (cons nil (map (partial parse-element config) a))))
 
   #?(:clj clojure.lang.Keyword
      :cljs Keyword)

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -61,9 +61,9 @@
 
 (defn props->clj [props]
   (let [props (utils/shallow-js->clj props :keywordize-keys true)]
-    ;; provide `:class-name` property also as `:class`
+    ;; provide `:class-name` property also as `:class` for backwards compat
     (-> props
-        (also-as :class-name :class))))
+        (also-as :class :class-name))))
 
 (comment
   (props->clj #js {"x0" 1})
@@ -76,6 +76,7 @@
 
   (props->clj #js {"testTest.asdf?" 1})
 
+  (props->clj #js {"class" ["asdf"]})
   )
 
 (defn $ [el & args] (hiccup/make-element react-hiccup-config el args))

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -23,7 +23,11 @@
      ;; props
      (case [(string? el) props?]
        [true true] (utils/clj->props props)
-       [false true] (utils/shallow-clj->js props)
+       [false true] (-> props
+                        (utils/also-as :class :className)
+                        (utils/also-as :for :htmlFor)
+                        (utils/styles->js)
+                        (utils/shallow-clj->js))
        nil)
 
      ;; children
@@ -71,13 +75,7 @@
    [{:value value}
     args]))
 
-(defn also-as
-  "If key `k1` is contained in `m`, assocs the value of it into `m` at key `k2`"
-  [m k1 k2]
-  (if-let [entry (find m k1)]
-    (let [[_ v] entry]
-      (assoc m k2 v))
-    m))
+
 
 (comment
   (also-as {:a 1} :a :b)
@@ -90,7 +88,9 @@
   (let [props (utils/shallow-js->clj props :keywordize-keys true)]
     ;; provide `:class-name` property also as `:class` for backwards compat
     (-> props
-        (also-as :class :class-name))))
+        (utils/also-as :class :class-name)
+        ;; (also-as :for :htmlFor)
+        )))
 
 (comment
   (props->clj #js {"x0" 1})

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -74,23 +74,6 @@
                                  :else x))]
              (thisfn x))))
 
-#?(:clj (defn shallow-clj->js
-          [x & {:keys [keyword-fn]
-                :or   {keyword-fn name}
-                :as options}]
-          x
-          (cond
-            (nil? x) nil
-            (keyword? x) (keyword-fn x)
-            (symbol? x) (str x)
-            (map? x) (let [kvs (reduce-kv
-                                (fn [c k v]
-                                  (conj c (hx.utils/shallow-clj->js k) v)) [] x)]
-                       (list* 'js-obj kvs))
-            (coll? x) (list* 'js/Array x)
-            :else x)
-          ))
-
 #_(shallow-clj->js [1 2 3])
 #_(shallow-clj->js {:a "asdf" :b :y :c 2})
 

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -2,6 +2,14 @@
   (:require [clojure.string :as str]
             #?(:cljs [goog.object :as gobj])))
 
+(defn also-as
+  "If key `k1` is contained in `m`, assocs the value of it into `m` at key `k2`"
+  [m k1 k2]
+  (if-let [entry (find m k1)]
+    (let [[_ v] entry]
+      (assoc m k2 v))
+    m))
+
 (defn camel->kebab
   "Converts from camel case (e.g. Foo or FooBar) to kebab case
    (e.g. foo or foo-bar)."

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -133,17 +133,10 @@
 
 ;; I stole most of this from https://github.com/rauhs/hicada/blob/master/src/hicada/util.clj
 
-;; in CLJS construct an array out of args
-#?(:cljs (defn join-classes-js
-           ([] "")
-           ([& xs]
-            (apply js/Array xs))))
-
 (defn join-classes
   "Join the `classes` with a whitespace."
   [classes]
-  (->> (map #(if (string? %) % (seq %)) classes)
-       (flatten)
+  (->> classes
        (remove nil?)
        (str/join " ")))
 
@@ -187,13 +180,8 @@
             (string? value))
         value
 
-        (and (or (sequential? value)
-                 (set? value))
-             (every? string? value))
+        (coll? value)
         (join-classes value)
-
-        (vector? value)
-        (apply join-classes-js value)
 
         :else value))
 
@@ -238,8 +226,12 @@
                (shallow-clj->js))))
 
 (comment
+  (reactify-props {:class ["foo" nil]})
+
   (clj->props {:class "foo"
                :style {:color "red"}})
+
+  (clj->props {:class [nil "foo"]})
 
   (let [case {:x-x? "asdf"}]
     (-> (clj->props case)

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -180,7 +180,8 @@
             (string? value))
         value
 
-        (coll? value)
+        (or (sequential? value)
+            (set? value))
         (join-classes value)
 
         :else value))

--- a/test/hx/hooks_test.cljs
+++ b/test/hx/hooks_test.cljs
@@ -144,7 +144,7 @@
                        (u/click)
                        (u/click))]
     (t/is (u/node= (u/html "<div>3</div>")
-                   (u/pret state-test)))))
+                   state-test))))
 
 (hx/defnc StateWithEffect [{:keys [receive]}]
   (let [count (hooks/<-state 0)]

--- a/test/hx/hooks_test.cljs
+++ b/test/hx/hooks_test.cljs
@@ -9,6 +9,11 @@
 (t/use-fixtures :each
   {:after rtl/cleanup})
 
+
+;;
+;; <-effect
+;;
+
 (t/deftest <-effect
   (t/testing "no deps, fires on every render"
     (let [counter (atom 0)
@@ -120,6 +125,11 @@
     (t/is (u/node= (u/html "<div>1</div>")
                    (u/root val-test)) "set")))
 
+
+;;
+;; <-state
+;;
+
 (hx/defnc OnClickState [_]
   (let [count (hooks/<-state 0)]
     [:div {:on-click #(swap! count inc)}
@@ -134,7 +144,7 @@
                        (u/click)
                        (u/click))]
     (t/is (u/node= (u/html "<div>3</div>")
-                   state-test))))
+                   (u/pret state-test)))))
 
 (hx/defnc StateWithEffect [{:keys [receive]}]
   (let [count (hooks/<-state 0)]

--- a/test/hx/hooks_test.cljs
+++ b/test/hx/hooks_test.cljs
@@ -171,7 +171,7 @@
     [f p]))
 
 (t/deftest <-state-with-effect
-  (let [[receive received] (receiver 20)
+  (let [[receive received] (receiver 30)
         state-test (-> (hx/f [StateWithEffect {:receive receive}])
                        (u/render)
                        (u/root)

--- a/test/hx/react_test.cljs
+++ b/test/hx/react_test.cljs
@@ -111,13 +111,20 @@
 
 (t/deftest class-prop
   (t/is (node= (html "<div class=\"foo\">hi</div>")
-               (root (render (hx/f [:div {:class "foo"} "hi"])))))
+               (root (render (hx/f [:div {:class "foo"} "hi"]))))
+        "bare string")
 
   (t/is (node= (html "<div class=\"foo\">hi</div>")
-               (root (render (hx/f [:div {:class ["foo"]} "hi"])))))
+               (root (render (hx/f [:div {:class ["foo"]} "hi"]))))
+        "vec")
 
   (t/is (node= (html "<div class=\"foo bar\">hi</div>")
-               (root (render (hx/f [:div {:class ["foo" "bar"]} "hi"]))))))
+               (root (render (hx/f [:div {:class ["foo" "bar"]} "hi"]))))
+        "vec with multi")
+
+  (t/is (node= (html "<div class=\"foo bar\">hi</div>")
+               (pret (root (render (hx/f [:div {:class ["foo" nil "bar"]} "hi"])))))
+        "vec with nils"))
 
 (t/deftest on-click-prop
   (let [on-click (func)

--- a/test/hx/react_test.cljs
+++ b/test/hx/react_test.cljs
@@ -107,7 +107,13 @@
 
   (t/is (node= (html "<div style=\"color: red; background: green;\">hi</div>")
                (root (render (hx/f [:div {:style {:color "red"
-                                                         :background "green"}} "hi"]))))))
+                                                  :background "green"}} "hi"])))))
+
+  (let [c (fn [props] (hx/f [:div {:style (.-style props)} "hi"]))]
+    (t/is (node= (html "<div style=\"color: red; background: green;\">hi</div>")
+                 (root (render (hx/f [c {:style {:color "red"
+                                                 :background "green"}} "hi"]))))
+          "style pass-through")))
 
 (t/deftest class-prop
   (t/is (node= (html "<div class=\"foo\">hi</div>")
@@ -123,8 +129,19 @@
         "vec with multi")
 
   (t/is (node= (html "<div class=\"foo bar\">hi</div>")
-               (pret (root (render (hx/f [:div {:class ["foo" nil "bar"]} "hi"])))))
-        "vec with nils"))
+               (root (render (hx/f [:div {:class ["foo" nil "bar"]} "hi"]))))
+        "vec with nils")
+
+  (let [c (fn [props]
+            (hx/f [:div (str (= (.-className props) "foo"))]))]
+    (t/is (node= (html "<div>true</div>")
+                 (-> [c {:class "foo"}] (hx/f) (render) (root))))))
+
+(t/deftest for-prop
+  (let [c (fn [props]
+            (hx/f [:div (str (= (.-htmlFor props) "foo"))]))]
+    (t/is (node= (html "<div>true</div>")
+                 (-> [c {:for "foo"}] (hx/f) (render) (root))))))
 
 (t/deftest on-click-prop
   (let [on-click (func)


### PR DESCRIPTION
This PR changes the way that `hx.hiccup` converts props when parsing hiccup, so that it will only do camel->kebab and other munging if the element being passed the props is a keyword (e.g. `:div`, `:span`).

It also changes  the way `hx.react/defnc` parses the props object, so that it will not do camel->kebab and other munging.

The following code exemplifies the new behavior:

```clojure
(defnc Foo [{:keys [text-to-render]}]
  [:div {:style {:color "red"}} "Foo: " text-to-render])

(hx/f [Foo {:text-to-render "This text shows"}])

(hx/f [Foo {:textToRender "This text doesn't show"}])

(defnc Bar [{:keys [textToRender]}]
  [:div {:style {:color "blue"}} "Bar: " textToRender])

(hx/f [Bar {:text-to-render "This text doesn't show"}])

(hx/f [Bar {:textToRender "This text shows"}])
```

`:class` is special-cased to be made available as `:class-name` for backwards compatibility reasons.