### PR TITLE
Remove atomified <-state, optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ A simple, easy to use library for React development in ClojureScript.
 ;; elements. You may use it just like any normal React component.
 (defnc MyComponent [{:keys [initial-name]}]
   ;; use React Hooks for state management
-  (let [name (<-state initial-name)]
+  (let [[name update-name] (<-state initial-name)]
     [:<>
      [:div "Hello " 
-      [:span {:style {:font-weight "bold"}} @name] "!"]
-     [:div [:input {:on-change #(reset! name (-> % .-target .-value))}]]]))
+      [:span {:style {:font-weight "bold"}} name] "!"]
+     [:div [:input {:on-change #(update-name (-> % .-target .-value))}]]]))
 
 (react-dom/render
   ;; hx/f transforms Hiccup into a React element.

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -27,15 +27,24 @@ The idiom that this library provides is: any Hook starts with `<-`
 (instead of `use`) to provide at-a-glance recognition of what Hooks a component
 uses.
 
-Anything missing from here can also be accessed via the React library, e.g.:
-`(react/useMemo)`.
-
 All of the [Rules of Hooks](https://reactjs.org/docs/hooks-overview.html#%EF%B8%8F-rules-of-hooks)
 apply.
 
 ### <-state: ([initial])
 
-Takes an initial value. Returns an atom that will re-render component on change.
+Takes an initial value. Returns a tuple `[value set-value]`, where `set-value`
+is a function that can be used like:
+
+```clojure
+;; a raw value
+(set-value {:this-is "new state"})
+
+;; a function to apply
+(set-value (fn [old-state] (conj old-state :updated)))
+
+;; a function to apply and arguments to prepend
+(set-value conj :update)
+```
 
 ### <-ref: ([initial])
 
@@ -48,30 +57,46 @@ Takes an atom. Returns the currently derefed value of the atom, and re-renders
 the component on change.
 
 ### <-reducer: ([reducer initialArg init])
+
 Just [react/useReducer](https://reactjs.org/docs/hooks-reference.html#usereducer).
 
 ### <-effect: ([f deps])
+
 Just [react/useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect).
 `deps` can be a CLJS collection.
 
 ### <-context: ([context])
+
 Just [react/useContext](https://reactjs.org/docs/hooks-reference.html#usecontext).
 
 ### <-memo: ([f deps])
+
 Just [react/useMemo](https://reactjs.org/docs/hooks-reference.html#usememo).
 `deps` can be a CLJS collection.
 
+### <-value: ([x])
+
+Caches `x`. When a new `x` is passed in, returns new `x` only if it is
+not equal to the previous `x`.
+
+Useful for optimizing `<-effect` et. al. when you have two values that might
+be structurally equal by referentially different.
+
 ### <-callback: ([f])
+
 Just [react/useCallback](https://reactjs.org/docs/hooks-reference.html#usecallback).
 
 ### <-imperative-handle: ([ref createHandle deps])
+
 Just [react/useImperativeHandle](https://reactjs.org/docs/hooks-reference.html#useimperativehandle).
 `deps` can be a CLJS collection.
 
 ### <-layout-effect: ([f deps])
+
 Just [react/useLayoutEffect](https://reactjs.org/docs/hooks-reference.html#uselayouteffect).
 `deps` can be a CLJS collection.
 
 ### <-debug-value: ([v formatter])
+
 Just [react/useDebugValue](https://reactjs.org/docs/hooks-reference.html#usedebugvalue).
 `deps` can be a CLJS collection.

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -53,8 +53,8 @@ change.
 
 ### <-deref: ([iref])
 
-Takes an atom. Returns the currently derefed value of the atom, and re-renders 
-the component on change.
+Takes an atom. Returns the currently derefed value of the atom, and queues a 
+re-render of the component on change.
 
 ### <-reducer: ([reducer initialArg init])
 

--- a/docs/why-not-reagent.md
+++ b/docs/why-not-reagent.md
@@ -21,7 +21,7 @@ However, in 2019, React is releasing a number of things in the core library:
 
 So far, only React Hooks has fully landed; Suspense is not stable yet except for lazy loading components, and async rendering is currently opt-in and considered unstable.
 
-However, in my experience, most of the value-add of Reagent comes from it's ability to access and update state in a very ergonomic way (atoms), and convert hiccup to React elements. This is why I think that `hx` is a better decision now: you can get the same ergonomics of Reagent with `hx` and React Hooks, today, with less code and better interop.
+However, in my experience, most of the value-add of Reagent comes from it's ability to access and update state in a very ergonomic way, and convert hiccup to React elements. This is why I think that `hx` is a better decision now: you can get the same ergonomics of Reagent with `hx` and React Hooks, today, with less code and better interop.
 
 This is insanely long, but I want to leave you with a couple examples. A short snippet of component-local state:
 
@@ -41,11 +41,11 @@ hx + Hooks code:
 
 ```clojure
 (defnc count-widget [{:keys [foo bar]}]
-  (let [state (<-state {:count 0})]
+  (let [[state set-state] (<-state {:count 0})]
     [:div 
      [:div "Foo: " foo] [:div "Bar: " bar]
      [:div "Count: " (:count state)]
-     [:button {:on-click #(swap! state update :count inc)} "+"]]))
+     [:button {:on-click #(set-state update :count inc)} "+"]]))
 ```
 
 Another, more complex example:

--- a/examples/workshop/core.cljs
+++ b/examples/workshop/core.cljs
@@ -180,16 +180,15 @@
   (hx/f [NamespaceKeywords {:namespace/value "hhhhh"}]))
 
 (hx/defnc StateWithEffect [{:keys [receive]}]
-  (let [count (hooks/<-state 0)]
+  (let [[count update-count] (hooks/<-state 0)]
     (hooks/<-effect
      (fn []
        (js/setTimeout
         (fn []
-          (prn @count))
-        3000)
-       js/undefined))
-    [:div {:on-click #(swap! count inc)}
-     @count]))
+          (prn count))
+        3000)))
+    [:div {:on-click #(update-count inc)}
+     count]))
 
 (dc/defcard state-with-effect
   (hx/f [StateWithEffect]))
@@ -200,12 +199,12 @@
 
 (hx/defnc WhenApplied [_]
   (reset! lifecycle :rendering)
-  (let [count (hooks/<-state 0)]
+  (let [[count update-count] (hooks/<-state 0)]
     (reset! lifecycle nil)
-    [:div {:on-click #(swap! count (fn [n]
-                                     (prn "update:" @lifecycle)
-                                     (inc n)))}
-     @count]))
+    [:div {:on-click #(update-count (fn [n]
+                                      (prn "update:" @lifecycle)
+                                      (inc n)))}
+     count]))
 
 (dc/defcard when-applied
   (hx/f [WhenApplied]))
@@ -213,9 +212,9 @@
 (def schedule (atom :high))
 
 (hx/defnc Scheduler [_]
-  (let [updates (hooks/<-state [])]
+  (let [[updates set-updates] (hooks/<-state [])]
     [:div
-     [:div "Updates: " (prn-str @updates)]
+     [:div "Updates: " (prn-str updates)]
      [:div
       [:input
        {:on-change (fn update []
@@ -223,11 +222,11 @@
                        :low (do
                               (reset! schedule :high)
                               (scheduler/unstable_scheduleCallback
-                               #(swap! updates conj :low)))
+                               #(set-updates conj :low)))
                        :high (do
                                (reset! schedule :low)
-                               (swap! updates conj :high))))}]]
-     [:div [:button {:on-click #(reset! updates [])} "reset"]]]))
+                               (set-updates conj :high))))}]]
+     [:div [:button {:on-click #(set-updates [])} "reset"]]]))
 
 (dc/defcard scheduler
   (hx/f [react/unstable_ConcurrentMode

--- a/examples/workshop/sortable.cljs
+++ b/examples/workshop/sortable.cljs
@@ -27,16 +27,16 @@
 
 (hx/defnc SortableComponent [_]
   ;; use the <-state Hook to keep track of and update the state
-  (let [items (<-state #js ["Item 1"
-                            "Item 2"
-                            "Item 3"
-                            "Item 4"
-                            "Item 5"
-                            "Item 6"])]
+  (let [[items update-items] (<-state #js ["Item 1"
+                                           "Item 2"
+                                           "Item 3"
+                                           "Item 4"
+                                           "Item 5"
+                                           "Item 6"])]
     [:div
      "Click and drag an item to re-arrange them!"
-     [SortableList {:items @items
-                    :onSortEnd #(swap! items move-item %)}]]))
+     [SortableList {:items items
+                    :onSortEnd #(update-items move-item %)}]]))
 
 (dc/defcard example
   (hx/f [SortableComponent]))

--- a/examples/workshop/state.cljs
+++ b/examples/workshop/state.cljs
@@ -9,10 +9,10 @@
 ;;
 
 (defnc Simple [_]
-  (let [state (<-state 0)]
+  (let [[state set-state] (<-state 0)]
     [:<>
-     [:div "Counter: " @state]
-     [:div [:button {:on-click #(swap! state inc)} "inc"]]]))
+     [:div "Counter: " state]
+     [:div [:button {:on-click #(set-state inc)} "inc"]]]))
 
 (dc/defcard simple
   (hx/f [Simple]))
@@ -24,14 +24,14 @@
 
 (defnc Timer
   [opts]
-  (let [seconds (<-state 0)]
+  (let [[seconds update-seconds] (<-state 0)]
     (<-effect (fn []
-                (let [id (js/setInterval #(swap! seconds inc) 1000)]
+                (let [id (js/setInterval #(update-seconds inc) 1000)]
                   (fn []
                     (js/clearInterval id))))
               [])
     [:div
-     "Timer: " @seconds]))
+     "Timer: " seconds]))
 
 (dc/defcard timer
   (hx/f [Timer]))
@@ -44,26 +44,27 @@
 (def app-state (react/createContext))
 
 (defnc App [{:keys [children]}]
-  (let [state (<-state {})]
-    [(.-Provider app-state) {:value state}
+  (let [[state set-state] (<-state {})]
+    [:provider {:context app-state
+                :value [state set-state]}
      children]))
 
 (defnc CounterConsumer [_]
-  (let [state (<-context app-state)
-        {:keys [counter]} @state]
+  (let [[state set-state] (<-context app-state)
+        {:keys [counter]} state]
     [:<>
      [:div "Counter: " counter]
-     [:button {:on-click #(swap! state update :counter inc)} "inc"]]))
+     [:button {:on-click #(set-state update :counter inc)} "inc"]]))
 
 (defnc PrintStateConsumer [_]
-  (let [state (<-context app-state)]
-    [:pre (prn-str @state)]))
+  (let [[state] (<-context app-state)]
+    [:pre (prn-str state)]))
 
 (defnc TimerConsumer [_]
-  (let [state (<-context app-state)
-        {:keys [timer]} @state]
+  (let [[state set-state] (<-context app-state)
+        {:keys [timer]} state]
     (<-effect (fn []
-                (let [id (js/setInterval #(swap! state update :timer inc) 1000)]
+                (let [id (js/setInterval #(set-state update :timer inc) 1000)]
                   (fn []
                     (js/clearInterval id))))
               [])

--- a/src/hx/hooks.cljs
+++ b/src/hx/hooks.cljs
@@ -90,7 +90,7 @@
   ([f]
    (react/useEffect f))
   ([f deps]
-   (react/useEffect f #js [(<-clj-deps deps)])))
+   (react/useEffect f (to-array deps))))
 
 (def <-context
   "Just react/useContext"
@@ -103,7 +103,7 @@
 (defn <-callback
   "Just react/useCallback"
   ([f] (react/useCallback f))
-  ([f deps] (react/useCallback f #js [(<-clj-deps deps)])))
+  ([f deps] (react/useCallback f (to-array deps))))
 
 (defn <-imperative-handle
   "Just react/useImperativeHandle"
@@ -111,12 +111,12 @@
    (react/useImperativeHandle ref create-handle))
   ([ref create-handle deps]
    (react/useImperativeHandle ref create-handle
-                              #js [(<-clj-deps deps)])))
+                              (to-array deps))))
 
 (defn <-layout-effect
   "Just react/useLayoutEffect"
   ([f] (react/useLayoutEffect f))
-  ([f deps] (react/useLayoutEffect f #js [<-clj-deps deps])))
+  ([f deps] (react/useLayoutEffect f (to-array deps))))
 
 (def <-debug-value
   "Just react/useDebugValue"

--- a/src/hx/hooks.cljs
+++ b/src/hx/hooks.cljs
@@ -60,8 +60,17 @@
   on change."
   [initial]
   (let [react-ref (react/useRef initial)
-        update-ref (fn [v] (gobj/set react-ref "current" v))]
-  (Atomified. [react-ref update-ref] #(.-current ^js %))))
+        update-ref (fn updater
+                     ([x]
+                      (if-not (ifn? x)
+                        (gobj/set react-ref "current" x)
+                        (gobj/set react-ref "current"
+                                  (x (gobj/get react-ref "current")))))
+                     ([f & xs]
+                      (updater (fn spread-updater [x]
+                                 (apply f x xs)))))]
+    (prn react-ref)
+    (Atomified. [react-ref update-ref] #(.-current ^js %))))
 
 (defn <-deref
   "Takes an atom. Returns the currently derefed value of the atom, and re-renders

--- a/src/hx/hooks.cljs
+++ b/src/hx/hooks.cljs
@@ -69,7 +69,6 @@
                      ([f & xs]
                       (updater (fn spread-updater [x]
                                  (apply f x xs)))))]
-    (prn react-ref)
     (Atomified. [react-ref update-ref] #(.-current ^js %))))
 
 (defn <-deref

--- a/test/hx/hooks_test.cljs
+++ b/test/hx/hooks_test.cljs
@@ -137,6 +137,22 @@
     [:div {:on-click #(update-count inc)}
      count]))
 
+(t/deftest <-ref
+  (let [ref-test (fn [props]
+                   (let [ref (hooks/<-ref 0)]
+                     (swap! ref inc)
+                     (hx/f [:div @ref])))
+        rendering (u/render (hx/f [ref-test]))
+        re-render (.-rerender rendering)]
+    (t/is (u/node= (u/html "<div>1</div>")
+                   (u/pret (u/root rendering))))
+    (re-render (hx/f [ref-test]))
+    (t/is (u/node= (u/html "<div>2</div>")
+                   (u/pret (u/root rendering))))
+    (re-render (hx/f [ref-test]))
+    (t/is (u/node= (u/html "<div>3</div>")
+                   (u/pret (u/root rendering))))   ))
+
 (t/deftest <-state
   (let [state-test (-> (hx/f [OnClickState])
                        (u/render)


### PR DESCRIPTION
This MR removes the Atomified wrapper returned by `<-state`. It implements a couple of new features:

1. `<-state` returns a tuple `[state set-state]`
2. `set-state` will prevent re-renders triggered by structurally equivalent state objects
3. `set-state` can be used with multiple arguments like `swap!`: `(set-state assoc :new-key "new-value")`
4. Adds a new `<-value` hook that can be used to optimize `<-effect`, `<-memo`, etc.