### PR TITLE
<-smart-effect

### DIFF
--- a/src/hx/hooks.clj
+++ b/src/hx/hooks.clj
@@ -1,0 +1,23 @@
+(ns hx.hooks
+  (:require [cljs.analyzer.api]))
+
+(defn- resolve-vars [env body]
+  (let [sym-list (atom #{})]
+    (clojure.walk/postwalk
+     (fn w [x]
+       (if (symbol? x)
+         (do (swap! sym-list conj x)
+             x)
+         x))
+     body)
+    (->> @sym-list
+         (map (partial cljs.analyzer.api/resolve env))
+         (filter (comp not nil?))
+         (map :name)
+         vec)))
+
+(defmacro <-smart-effect [& body]
+  (let [deps (resolve-vars &env body)]
+    `(<-effect (fn []
+                 ~@body)
+               ~deps)))

--- a/src/hx/hooks.clj
+++ b/src/hx/hooks.clj
@@ -21,3 +21,15 @@
     `(<-effect (fn []
                  ~@body)
                ~deps)))
+
+(defmacro <-smart-layout-effect [& body]
+  (let [deps (resolve-vars &env body)]
+    `(<-layout-effect (fn []
+                 ~@body)
+               ~deps)))
+
+(defmacro <-smart-memo [& body]
+  (let [deps (resolve-vars &env body)]
+    `(<-memo (fn []
+               ~@body)
+             ~deps)))


### PR DESCRIPTION
This PR proposes a new hook macro: `<-smart-effect` (working title 😛)

The `<-smart-effect` macro aims to solve the same problem as the eslint-plugin-react-hooks rule "exhaustive deps". https://github.com/facebook/react/issues/14920

`<-smart-effect` is a macro that works like `<-effect`, but instead of passing it a function and set of deps, you pass it a body like so:

```clojure
(<-smart-effect
  (set-value inc))
```

`<-smart-effect` will detect the vars/local bindings you have used in the body, and will expand to:

```clojure
(<-effect
  (fn []
    (set-value inc))
  [set-value cljs.core/inc])
```

Thus ensuring that we always re-run our effect anytime we re-render with new values.

I don't want to make this the default for `<-effect` because there may be times where you want more fine-grained control over your effect firing, as well as giving people the ability to bail out if there are bugs found in the new `<-smart-effect` hook.

We could also do the same for `<-layout-effect`, `<-memo`, etc.