### PR TITLE
Hiccup parsing perf improvements

### DIFF
--- a/benchmark/hx/benchmark.cljs
+++ b/benchmark/hx/benchmark.cljs
@@ -37,14 +37,17 @@
         (rce "button" nil "ok")
         (rce "button" nil "cancel")))))
 
-(hx/defnc hx-render [{:keys [title body]}]
-  [:div {:class "card"}
-   [:div {:class "card-title"} title]
-   [:div {:class "card-body"} body]
-   [:div {:class "card-footer"}
-    [:div {:class "card-actions"}
-     [:button "ok"]
-     [:button "cancel"]]]])
+(defn hx-render [{:keys [title body]}]
+  (hx/f
+   [:div {:class "card"}
+    [:div {:class "card-title"} title]
+    [:div {:class "card-body"} body]
+    [:div {:class "card-footer"}
+     [:div {:class "card-actions"}
+      [:button "ok"]
+      [:button "cancel"]]]]))
+
+(def ^:export hx-render-manual hx-render)
 
 (defn log-cycle [event]
   (println (.toString (.-target event))))
@@ -53,7 +56,7 @@
   (this-as this
     (js/console.log this)))
 
-(defn main [& args]
+(defn ^:export main [& args]
   (let [test-data {:title "hello world"
                    :body "body"}
         test-data-js #js {:title "hello world"
@@ -61,19 +64,19 @@
     (println (rdom/renderToString (react-render test-data)))
     (println (rdom/renderToString (reagent-render test-data)))
     ;; (println (rdom/renderToString (shadow-render test-data)))
-    (println (rdom/renderToString (hx-render test-data-js nil)))
+    (println (rdom/renderToString (hx-render test-data)))
 
     (when-not (= (rdom/renderToString (react-render test-data))
                  (rdom/renderToString (reagent-render test-data))
                  ;; (rdom/renderToString (shadow-render test-data))
-                 (rdom/renderToString (hx-render test-data-js nil)))
+                 (rdom/renderToString (hx-render test-data)))
       (throw (ex-info "not equal!" {})))
 
     (-> (b/Suite.)
-        ;; (.add "react" #(react-render test-data))
+        (.add "react" #(react-render test-data))
         (.add "reagent" #(reagent-render test-data))
         ;; (.add "shadow" #(shadow-render test-data))
-        (.add "hx" #(hx-render test-data-js nil))
+        (.add "hx" #(hx-render test-data))
         (.on "cycle" log-cycle)
         ;; (.on "complete" log-complete)
         (.run))))

--- a/benchmark/hx/benchmark.cljs
+++ b/benchmark/hx/benchmark.cljs
@@ -66,11 +66,11 @@
     (when-not (= (rdom/renderToString (react-render test-data))
                  (rdom/renderToString (reagent-render test-data))
                  ;; (rdom/renderToString (shadow-render test-data))
-                 (rdom/renderToString (hx-render test-data nil)))
+                 (rdom/renderToString (hx-render test-data-js nil)))
       (throw (ex-info "not equal!" {})))
 
     (-> (b/Suite.)
-        (.add "react" #(react-render test-data))
+        ;; (.add "react" #(react-render test-data))
         (.add "reagent" #(reagent-render test-data))
         ;; (.add "shadow" #(shadow-render test-data))
         (.add "hx" #(hx-render test-data-js nil))

--- a/examples/workshop/core.cljs
+++ b/examples/workshop/core.cljs
@@ -166,7 +166,7 @@
    [:ul
     [:li "class: \"" class "\""]
     [:li "class-name: \"" class-name "\""]]
-   (str (= class class-name))])
+   (str (= class class-name "foo"))])
 
 (dc/defcard class-name-prop
   (hx/f [ClassNameProp {:class "foo"}]))
@@ -265,8 +265,8 @@
   [:<>
    [:div "Cloned:"
     (react/cloneElement children #js {:className "foo"})]
-   ;; [:div "Not cloned:"
-   ;;  children]
+   [:div "Not cloned:"
+    children]
    ])
 
 (hx/defnc Cloned [{:keys [className class] :as props}]

--- a/public/benchmark/index.html
+++ b/public/benchmark/index.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <meta charset="UTF-8">
+    </head>
+    <body>
+        <script src="js/main.js"></script>
+        <script>hx.benchmark.main()</script>
+    </body>
+</html>

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -31,5 +31,12 @@
   :benchmark {:target :node-script
               :main hx.benchmark/main
               :output-to "target/benchmark/index.js"
-              :devtools {;; :enabled false
-                         :after-load hx.benchmark/main}}}}}
+              :devtools {:enabled false
+                         ;; :after-load hx.benchmark/main
+                         }}
+  :benchmark-browser {:target :browser
+                      :output-dir "public/benchmark/js"
+                      :asset-path "/js"
+                      :modules {:main {:entries [hx.benchmark]}}
+                      :devtools {:http-root "public/benchmark"
+                                 :http-port    8800}}}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -31,8 +31,8 @@
   :benchmark {:target :node-script
               :main hx.benchmark/main
               :output-to "target/benchmark/index.js"
-              :devtools {:enabled false
-                         ;; :after-load hx.benchmark/main
+              :devtools {;; :enabled false
+                         :after-load hx.benchmark/main
                          }}
   :benchmark-browser {:target :browser
                       :output-dir "public/benchmark/js"

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -107,6 +107,6 @@
 
       :default
       (throw
-       (ex (str "Unknown element type " (prn-str (type el))
+       (ex (str "Unknown element type " (pr-str (type el))
                 " found while parsing hiccup form: "
                 (.toString el)))))))

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -1,28 +1,36 @@
 (ns hx.hiccup
   (:require [clojure.walk :as walk]
-            [hx.utils :as util]))
+            [hx.utils :as util :include-macros true]))
 
 (defprotocol IElement
   (-parse-element [el config args] "Parses an element"))
+
+;; (declare -parse-element)
 
 ;; we use a multimethod to dispatch on identity so that consumers
 ;; can override this for custom values e.g. :<> for React fragments
 (defmulti parse-element
   (fn [config el args]
-    (identity el))
+    el)
   :default ::default)
 
 ;; if no multimethod for specific el, then apply general parsing rules
 (defmethod parse-element
   ::default
   ([config el args]
-   (-parse-element el config args)))
+   (util/measure-perf
+    "parse_element_default"
+    (-parse-element el config args))))
 
 (defn parse [config hiccup]
-  (parse-element config (first hiccup) (rest hiccup)))
+  (util/measure-perf
+   "parse"
+   (parse-element config (nth hiccup 0) (rest hiccup))))
 
 (defn make-element [config el args]
-  ((:create-element config) config el args))
+  (util/measure-perf
+   "make_element"
+   ((:create-element config) config el args)))
 
 #?(:clj (defn array? [x]
           (coll? x)))
@@ -31,64 +39,119 @@
   #?(:clj (Exception. s)
      :cljs (js/Error. s)))
 
+;; (defn -parse-element [form config args]
+;;   (cond
+;;     (nil? form) form
+
+;;     (number? form) form
+
+;;     (string? form) form
+
+;;     (vector? form) (parse-element config (-nth form 0) (rest form))
+
+;;     (seq? form) (make-element config (:fragment config)
+;;                               (cons nil (map #(parse-element config (first %) (rest %)) form)))
+
+;;     (keyword? form) (make-element config (name form) args)
+
+;;     (ifn? form) (make-element config form args)
+
+;;     ((:is-element? config) form) form
+
+;;     ((:is-element-type? config) form)
+;;     (make-element config form args)
+
+;;     ;; handle array of children already parsed
+;;     (and (array? form) (every? (:is-element? config) form))
+;;     form
+
+;;     (var? form)
+;;     (make-element config
+;;                   (fn VarEl [& args] (apply form args))
+;;                   args)
+
+;;     :default
+;;     (throw
+;;      (ex (str "Unknown element type " (prn-str (type form))
+;;               " found while parsing hiccup form: "
+;;                                 (.toString form))))
+
+;;     ))
+
 (extend-protocol IElement
   nil
   (-parse-element [_ _ _]
-    nil)
+    (util/measure-perf
+     "-parse_element_nil"
+     nil))
 
   #?(:clj Number
      :cljs number)
   (-parse-element [n _ _]
-    n)
+    (util/measure-perf
+     "-parse_element_number"
+     n))
 
   #?(:clj String
      :cljs string)
   (-parse-element [s _ _]
-    s)
+    (util/measure-perf
+     "-parse_element_string"
+     s))
 
   #?(:clj clojure.lang.PersistentVector
      :cljs PersistentVector)
   (-parse-element [form config _]
-    (parse-element config (first form) (rest form)))
+    (util/measure-perf
+     "-parse_element_vector"
+     (parse-element config (-nth form 0) (rest form))))
 
   #?(:clj clojure.lang.LazySeq
      :cljs LazySeq)
   (-parse-element [a config b]
+    (util/measure-perf
+     "-parse_element_lazyseq"
     (make-element
      config
      (:fragment config)
-     (cons nil (map #(parse-element config (first %) (rest %)) a))))
+     (cons nil (map #(parse-element config (first %) (rest %)) a)))))
 
   #?(:clj clojure.lang.Keyword
      :cljs Keyword)
   (-parse-element [el config args]
-    (make-element config (name el) args))
+    (util/measure-perf
+     "-parse_element_keyword"
+     (make-element config (name el) args)))
 
   #?(:clj clojure.lang.AFn
      :cljs function)
   (-parse-element [el config args]
-    (make-element config el args))
+    (util/measure-perf
+     "-parse_element_afn"
+     (make-element config el args)))
 
   #?(:clj Object
      :cljs default)
   (-parse-element [el config args]
-    (cond
-      ((:is-element? config) el) el
+    (util/measure-perf
+     "-parse_element_object"
+     (cond
+       ((:is-element? config) el) el
 
-      ((:is-element-type? config) el)
-      (make-element config el args)
+       ((:is-element-type? config) el)
+       (make-element config el args)
 
-      ;; handle array of children already parsed
-      (and (array? el) (every? (:is-element? config) el))
-      el
+       ;; handle array of children already parsed
+       (and (array? el) (every? (:is-element? config) el))
+       el
 
-      (var? el)
-      (make-element config
-                    (fn VarEl [& args] (apply el args))
-                    args)
+       (var? el)
+       (make-element config
+                     (fn VarEl [& args] (apply el args))
+                     args)
 
-      :default
-      (throw
-       (ex (str "Unknown element type " (prn-str (type el))
-                       " found while parsing hiccup form: "
-                       (.toString el)))))))
+       :default
+       (throw
+        (ex (str "Unknown element type " (prn-str (type el))
+                 " found while parsing hiccup form: "
+                 (.toString el))))))))

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -31,7 +31,7 @@
 
 (defn parse-tag [el]
   (cond
-    ^boolean (keyword? el) (-name el)
+    ^boolean (keyword? el) (tag->impl el)
     ^boolean (var? el) (fn VarEl [& args] (apply el args))
     true el))
 

--- a/src/hx/hiccup.cljc
+++ b/src/hx/hiccup.cljc
@@ -25,7 +25,7 @@
 (defn parse [config hiccup]
   (util/measure-perf
    "parse"
-   (parse-element config (nth hiccup 0) (rest hiccup))))
+   (parse-element config (-nth hiccup 0) (rest hiccup))))
 
 (defn make-element [config el args]
   (util/measure-perf

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -9,11 +9,7 @@
   (cond
     (and (string? el) props?) (utils/clj->props first-arg)
 
-    props? (-> first-arg
-               (utils/also-as :class :className)
-               (utils/also-as :for :htmlFor)
-               (utils/styles->js)
-               (utils/shallow-clj->js))
+    props? (utils/clj->props first-arg false)
 
     true nil))
 

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -19,7 +19,7 @@
   (fn [& args]
     (let [ret (apply first-child args)]
       (if (vector? ret)
-        (hiccup/-as-element ^non-native ret config)
+        (hiccup/-as-element ret config)
         ret))))
 
 (defn create-element [config el args]

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -35,10 +35,13 @@
                                      (hiccup/-parse-element ret config nil)
                                      ret))))
           (react/createElement el props (hiccup/-parse-element first-child config nil)))
-      (apply
-       react/createElement el props
-       ;; children
-       (mapv #(hiccup/-parse-element % config nil) children)))))
+      ;; use .apply here for performance
+      (.apply
+       react/createElement nil
+       (reduce (fn [a v]
+                 (.push a (hiccup/-parse-element v config nil))
+                 a)
+               #js [el props] children)))))
 
 (def react-hiccup-config
   {:create-element create-element

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -139,4 +139,3 @@
   a new React element"
   [component]
   (partial $ component))
-

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -5,6 +5,8 @@
             [hx.utils :as utils :include-macros true])
   (:require-macros [hx.react]))
 
+(def props->clj utils/props->clj)
+
 (defn- props [el first-arg props?]
   (cond
     (and (string? el) props?) (utils/clj->props first-arg)
@@ -85,8 +87,6 @@
     (f body)
     body))
 
-(declare props->clj)
-
 (def fragment react/Fragment)
 
 (hiccup/extend-tag :<> hx.react/fragment)
@@ -99,36 +99,6 @@
 (hiccup/extend-tag :provider Provider)
 
 
-(comment
-  (also-as {:a 1} :a :b)
-
-  (also-as {:a 1} :b :c)
-
-  )
-
-(defn props->clj [props]
-  (let [props (utils/shallow-js->clj props :keywordize-keys true)]
-    ;; provide `:class-name` property also as `:class` for backwards compat
-    (-> props
-        (utils/also-as :className :class)
-        (utils/also-as :class :class-name)
-        (utils/also-as :htmlFor :for)
-        ;; (also-as :for :htmlFor)
-        )))
-
-(comment
-  (props->clj #js {"x0" 1})
-
-  (props->clj #js {"test0" 1})
-
-  (props->clj #js {"testAsdf?" 1})
-
-  (props->clj #js {"test_asdf?" 1})
-
-  (props->clj #js {"testTest.asdf?" 1})
-
-  (props->clj #js {"class" ["asdf"]})
-  )
 
 (defn $ [el & args] (hiccup/make-element react-hiccup-config el args))
 

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -35,7 +35,7 @@
                    (if props? (-rest args) args))
          first-child (utils/measure-perf
                       "first-child"
-                      (-first children))]
+                      (first children))]
      (case (count children)
        0 (utils/measure-perf
           "no_children"
@@ -44,6 +44,7 @@
               "fn?"
               ^boolean (goog/isFunction first-child))
            (react/createElement el
+                                nil
                                 ;; fn-as-child
                                 ;; wrap in a function to parse hiccup from render-fn
                                 (fn [& args]

--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -6,10 +6,10 @@
             [hx.utils :as utils :include-macros true])
   (:require-macros [hx.react]))
 
-;; (extend-type react/Component
-;;   hiccup/IElement
-;;   (-parse-element [el config args]
-;;     (hiccup/make-element config el args)))
+(extend-type react/Component
+  hiccup/IElement
+  (-parse-element [el config args]
+    (hiccup/make-element config el args)))
 
 (defn create-element [config el args]
   (utils/measure-perf
@@ -32,7 +32,7 @@
                   true nil))
          children (utils/measure-perf
                    "children"
-                   (if props? (rest args) args))
+                   (if props? (-rest args) args))
          first-child (utils/measure-perf
                       "first-child"
                       (-first children))]
@@ -42,7 +42,7 @@
           (react/createElement el props))
        1 (if (utils/measure-perf
               "fn?"
-              (fn? first-child))
+              ^boolean (goog/isFunction first-child))
            (react/createElement el
                                 ;; fn-as-child
                                 ;; wrap in a function to parse hiccup from render-fn
@@ -104,8 +104,8 @@
   (hiccup/-parse-element
    (.-Provider context)
    react-hiccup-config
-   (into
-    [{:value value}]
+   (cons
+    {:value value}
     (rest args)))))
 
 

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -201,18 +201,19 @@
                         (reactify-props-kv k v))) {} attrs)
     attrs))
 
-#?(:cljs (defn styles->js [props]
-           (cond
-             (and (map? props) (:style props))
-             (assoc props :style (clj->js (:style props)))
+#?(:cljs (do (defn styles->js* [props]
+               (cond
+                 (and (map? props) (:style props))
+                 (assoc props :style (clj->js (:style props)))
 
-             (gobj/containsKey props "style")
-             (do (->> (gobj/get props "style")
-                      (clj->js)
-                      (gobj/set props "style"))
-                 props)
+                 (gobj/containsKey props "style")
+                 (do (->> (gobj/get props "style")
+                          (clj->js)
+                          (gobj/set props "style"))
+                     props)
 
-             :default props)))
+                 :default props))
+             (def styles->js (memoize styles->js*))))
 
 #?(:clj (defn clj->props [props] props)
    :cljs (do (defn clj->props* [props]

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -223,18 +223,19 @@
                         (reactify-props-kv k v))) {} attrs)
     attrs))
 
-#?(:cljs (defn styles->js [props]
-           (cond
-             (and (map? props) (:style props))
-             (assoc props :style (clj->js (:style props)))
+#?(:cljs (do (defn styles->js* [props]
+               (cond
+                 (and (map? props) (:style props))
+                 (assoc props :style (clj->js (:style props)))
 
-             (gobj/containsKey props "style")
-             (do (->> (gobj/get props "style")
-                      (clj->js)
-                      (gobj/set props "style"))
-                 props)
+                 (gobj/containsKey props "style")
+                 (do (->> (gobj/get props "style")
+                          (clj->js)
+                          (gobj/set props "style"))
+                     props)
 
-             :default props)))
+                 :default props))
+             (def styles->js (memoize1 styles->js*))))
 
 #?(:clj (defn clj->props [props] props)
    :cljs (do (defn clj->props* [props]

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -235,7 +235,7 @@
                      props)
 
                  :default props))
-             (def styles->js (memoize1 styles->js*))))
+             (def styles->js styles->js*)))
 
 #?(:clj (defn clj->props [props] props)
    :cljs (do (defn clj->props* [props]

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -243,7 +243,7 @@
                    (reactify-props)
                    (styles->js)
                    (shallow-clj->js)))
-             (def clj->props (memoize1 clj->props*))))
+             (def clj->props clj->props*)))
 
 (comment
   (reactify-props {:class ["foo" nil]})

--- a/src/hx/utils.cljc
+++ b/src/hx/utils.cljc
@@ -2,6 +2,21 @@
   (:require [clojure.string :as str]
             #?(:cljs [goog.object :as gobj])))
 
+(def ^:dynamic *perf-debug?* false)
+
+(defmacro measure-perf [tag form]
+  (if *perf-debug?*
+    (let [begin (str tag "_begin")
+          end (str tag "_end")]
+      `(do (js/performance.mark ~begin)
+           (let [ret# ~form]
+             (js/performance.mark ~end)
+             (js/performance.measure ~(str "measure_" tag)
+                                     ~begin
+                                     ~end)
+             ret#)))
+    form))
+
 (defn also-as
   "If key `k1` is contained in `m`, assocs the value of it into `m` at key `k2`"
   [m k1 k2]


### PR DESCRIPTION
Before:
```
react x 1,468,464 ops/sec ±1.52% (57 runs sampled)
reagent x 325,920 ops/sec ±0.38% (62 runs sampled)
hx x 44,782 ops/sec ±0.65% (58 runs sampled)
```

Current After:
```
react x 1,720,359 ops/sec ±0.45% (62 runs sampled)
reagent x 337,924 ops/sec ±0.43% (61 runs sampled)
hx x 178,537 ops/sec ±0.51% (62 runs sampled)
```

hx is still lagging behind reagent by about 30%. Current goal is to flesh out benchmark with more cases, and be able to at least match reagent in most cases.

My dream would be to achieve ~50% of raw React, but that might require some tradeoffs that aren't worth it.