### PR TITLE
Fix removed `goog.isFunction`

### DIFF
--- a/src/hx/react.cljs
+++ b/src/hx/react.cljs
@@ -1,5 +1,6 @@
 (ns hx.react
   (:require [goog.object :as gobj]
+            [goog.functions :as gfunc]
             ["react" :as react]
             [hx.hiccup :as hiccup]
             [hx.utils :as utils :include-macros true])
@@ -44,7 +45,7 @@
           (react/createElement el props))
        1 (if (utils/measure-perf
               "fn?"
-              ^boolean (goog/isFunction first-child))
+              ^boolean (gfunc/isFunction first-child))
            (react/createElement el
                                 props
                                 ;; fn-as-child


### PR DESCRIPTION
Replaced with `goog.functions.isFunction`

goog.isFunction was deleted from the Google Closure library: https://github.com/google/closure-library/commit/6342251d591d45b501dee07cbbdc605f22f73bcd#diff-effbfe8cf8cf58c5ee3e5b22d502b9b1764439c5bf01020bbfa4307da55b11ec